### PR TITLE
Zedmor 398 conditional sidebar ckoerber edits

### DIFF
--- a/src/chime_dash/app/pages/sidebar.py
+++ b/src/chime_dash/app/pages/sidebar.py
@@ -38,12 +38,19 @@ _SIDEBAR_ELEMENTS = ReadOnlyDict(OrderedDict(
     current_hospitalized={"type": "number", "min": 0, "step": 1},
     ###
     spread_parameters={"type": "header", "size": "h4"},
+    spread_parameters_checkbox={"type": "switch", "value": False},
     date_first_hospitalized={
         "type": "date",
         "min_date_allowed": datetime(2019, 10, 1),
         "max_date_allowed": datetime(2021, 12, 31),
     },
     doubling_time={"type": "number", "min": FLOAT_INPUT_MIN, "step": FLOAT_INPUT_STEP},
+    social_distancing_checkbox={"type": "switch", "value": False},
+    social_distancing_start_date={
+        "type": "date",
+        "min_date_allowed": datetime(2019, 10, 1),
+        "max_date_allowed": datetime(2021, 12, 31),
+    },
     relative_contact_rate={
         "type": "number",
         "min": 0.0,

--- a/src/chime_dash/app/pages/sidebar.py
+++ b/src/chime_dash/app/pages/sidebar.py
@@ -38,7 +38,7 @@ _SIDEBAR_ELEMENTS = ReadOnlyDict(OrderedDict(
     current_hospitalized={"type": "number", "min": 0, "step": 1},
     ###
     spread_parameters={"type": "header", "size": "h4"},
-    spread_parameters_checkbox={"type": "switch", "value": False},
+    pick_hospitalized_checkbox={"type": "switch", "value": False},
     date_first_hospitalized={
         "type": "date",
         "min_date_allowed": datetime(2019, 10, 1),

--- a/src/chime_dash/app/services/callbacks.py
+++ b/src/chime_dash/app/services/callbacks.py
@@ -1,19 +1,38 @@
-from typing import List
+from collections import OrderedDict, defaultdict
 from datetime import datetime
-from collections import OrderedDict
+from typing import List
 from urllib.parse import parse_qsl, urlencode
+
 from dash.exceptions import PreventUpdate
 
-from chime_dash.app.utils.callbacks import ChimeCallback, register_callbacks
 from chime_dash.app.utils import (
     get_n_switch_values,
     parameters_deserializer,
     parameters_serializer,
     prepare_visualization_group
 )
-
+from chime_dash.app.utils.callbacks import ChimeCallback, register_callbacks
 from penn_chime.models import SimSirModel
 from penn_chime.parameters import Parameters, Disposition
+
+
+class Multidict(defaultdict):
+
+    def __init__(self, obj):
+        super(Multidict, self).__init__(set)
+        for el in obj:
+            self.__setitem__(*el)
+
+    def __setitem__(self, key, value):
+        if isinstance(value, (self.default_factory)):  # self.default_factory is `set`
+            super().__setitem__(key, value)
+        else:
+            self[key].add(value)
+
+    def items(self):
+        for key in self.keys():
+            for v in self[key]:
+                yield key, v
 
 
 class ComponentCallbacks:
@@ -143,6 +162,19 @@ class SidebarCallbacks(ComponentCallbacks):
                 raise PreventUpdate
             return SidebarCallbacks.update_parameters(component_instance, *args)
 
+        def hospitalized_checkbox_to_first_date(i_know_first_hospitalized):
+            if not i_know_first_hospitalized:
+                return
+            else:
+                raise ValueError('Do not update')
+
+
+        def hospitalized_checkbox_to_doubling_time(i_know_first_hospitalized):
+            if i_know_first_hospitalized:
+                return
+            else:
+                raise ValueError('Do not update')
+
         super().__init__(
             component_instance=component_instance,
             callbacks=[
@@ -151,7 +183,17 @@ class SidebarCallbacks(ComponentCallbacks):
                     dom_updates={"sidebar-store": "data"},
                     callback_fn=update_parameters_helper,
                     stores=["sidebar-store"],
-                )
+                ),
+                ChimeCallback(
+                    changed_elements={'spread_parameters_checkbox': 'value'},
+                    dom_updates={'date_first_hospitalized': 'date'},
+                    callback_fn=hospitalized_checkbox_to_first_date
+                ),
+                ChimeCallback(
+                    changed_elements={'spread_parameters_checkbox': 'value'},
+                    dom_updates={'doubling_time': 'value'},
+                    callback_fn=hospitalized_checkbox_to_doubling_time
+                ),
             ]
         )
 
@@ -226,6 +268,7 @@ class RootCallbacks(ComponentCallbacks):
 
         def stores_changed_helper(root_mod, sidebar_mod, root_data, sidebar_data):
             return RootCallbacks.stores_changed(sidebar_inputs.keys(), root_mod, sidebar_mod, root_data, sidebar_data)
+
         super().__init__(
             component_instance=component_instance,
             callbacks=[

--- a/src/chime_dash/app/templates/en/sidebar.yml
+++ b/src/chime_dash/app/templates/en/sidebar.yml
@@ -3,10 +3,13 @@ population: Regional population
 market_share: Hospital market share (%)
 current_hospitalized: Currently hospitalized COVID-19 patients
 
+spread_parameters_checkbox: I know the date of the first hospitalized case.
 spread_parameters: Spread and Contact Parameters
 date_first_hospitalized: Date of first hospitalized case (enter this date to have CHIME estimate the initial doubling time)
 doubling_time: Doubling time in days (up to today. This overwrites date of first hospitalized estimation)
 relative_contact_rate: Social distancing (% reduction in social contact going forward)
+social_distancing_checkbox: Social distancing measures have been implemented
+social_distancing_start_date: Date of social distancing measures effect (may be delayed from implementation)
 
 severity_parameters: Severity Parameters
 hospitalized_rate: Hospitalization rate (% of total infections)

--- a/src/chime_dash/app/templates/en/sidebar.yml
+++ b/src/chime_dash/app/templates/en/sidebar.yml
@@ -3,8 +3,8 @@ population: Regional population
 market_share: Hospital market share (%)
 current_hospitalized: Currently hospitalized COVID-19 patients
 
-spread_parameters_checkbox: I know the date of the first hospitalized case.
 spread_parameters: Spread and Contact Parameters
+pick_hospitalized_checkbox: I know the date of the first hospitalized case.
 date_first_hospitalized: Date of first hospitalized case (enter this date to have CHIME estimate the initial doubling time)
 doubling_time: Doubling time in days (up to today. This overwrites date of first hospitalized estimation)
 relative_contact_rate: Social distancing (% reduction in social contact going forward)


### PR DESCRIPTION
This is a working example of how to use the `disabled` input option to decide which box to use (plus a later merge with develop). It does however not implement the entire sidebar as you did.

I am a little bit confused about the switch position value (see l118 and l170 of `callbacks.py`). And I have uncommented the URL parameter callbacks for testing purposes. It also works with them but sometimes, the switch position is resetted.
